### PR TITLE
Fix broken URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/nielstron/range_ex"
-Repository = "https://github.com/nielstron/range_ex"
+Homepage = "https://github.com/nielstron/range-ex"
+Repository = "https://github.com/nielstron/range-ex"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
The links in the sidebar on PyPI.org get 404 errors.